### PR TITLE
rbuildignore - dot to escaped dot

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,4 +13,4 @@ TODO\.md
 ^\.lintr$
 ^data-raw$
 ^.github$
-^staged_dependencies.yaml$
+^staged_dependencies\.yaml$


### PR DESCRIPTION
Update .Rbuildignore for ^stage_dependencies\\.yaml$.

Dot was not escaped