### PR TITLE
Update shinyRadioMatrix version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -43,7 +43,7 @@ Imports:
     rtables (>= 0.5.0),
     S4Vectors,
     scda (>= 0.1.3),
-    shinyRadioMatrix,
+    shinyRadioMatrix (>= 0.2.1),
     shinyWidgets,
     stats,
     stringr,
@@ -64,8 +64,6 @@ Suggests:
     testthat (>= 2.0)
 RdMacros:
     lifecycle
-Remotes:
-    szelepke/shinyRadioMatrix@2d861f2
 biocViews:
 Config/Needs/website: insightsengineering/nesttemplate
 Config/testthat/edition: 3


### PR DESCRIPTION
Given the version update, bumping up the version of `shinyRadioMatrix`.
Relates to https://github.com/insightsengineering/teal.modules.hermes/issues/243