### PR TITLE
Renamed drop-down to Select Categorical Subgroup Variable.

### DIFF
--- a/R/forestplot.R
+++ b/R/forestplot.R
@@ -120,7 +120,7 @@ ui_g_forest_tte <- function(id,
           collapsed = TRUE,
           title = "Additional Settings",
           sliderInput(ns("probs"), label = ("Probability Cutoff"), min = 0.01, max = 0.99, value = 0.5),
-          sampleVarSpecInput(ns("subgroups"), "Select Subgroup Variable")
+          sampleVarSpecInput(ns("subgroups"), "Select Categorical Subgroup Variable")
         )
       )
     ),


### PR DESCRIPTION
Hi team, 
This commit adds "Categorical" to description. I can also confirm that the variables outputted in the drop-down are only categorical. I also checked what happens if no categorical variables are present in the mae via SummarizedExperiment::colData(mae)["AGE"] . In such case the application runs correctly and simply outputs no variables to group by (empty list).
Fixes #198 


