### PR TITLE
adding rmarkdown to suggests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,7 +63,8 @@ Suggests:
     scda (>= 0.1.5),
     scda.2022 (>= 0.1.3),
     shinytest2 (>= 0.2.0),
-    testthat (>= 2.0)
+    testthat (>= 2.0),
+    rmarkdown
 VignetteBuilder:
     knitr
 RdMacros:


### PR DESCRIPTION
I got this error:
```
* creating vignettes ... ERROR
--- re-building ‘Getting_Started.Rmd’ using rmarkdown
Error: processing vignette 'Getting_Started.Rmd' failed with diagnostics:
The 'rmarkdown' package should be installed and declared as a dependency of the 'teal.modules.hermes' package (e.g., in the 'Suggests' field of DESCRIPTION), because the latter contains vignette(s) built with the 'rmarkdown' package. Please see https://github.com/yihui/knitr/issues/1864 for more information.
--- failed re-building ‘Getting_Started.Rmd’
```