### PR TITLE
fix: update some non-module examples

### DIFF
--- a/R/adtteSpec.R
+++ b/R/adtteSpec.R
@@ -154,7 +154,7 @@ adtteSpecInput <- function(inputId, # nolint
 #'
 #'   teal.widgets::standard_layout(
 #'     encoding = div(
-#'       experimentSpecInput(ns("experiment"), data = data, mae_name = "MAE"),
+#'       experimentSpecInput(ns("experiment"), data = reactive(data), mae_name = "MAE"),
 #'       assaySpecInput(ns("assay")),
 #'       geneSpecInput(ns("genes"), funs = list(Mean = colMeans)),
 #'       adtteSpecInput(ns("adtte"))

--- a/R/adtteSpec.R
+++ b/R/adtteSpec.R
@@ -150,6 +150,7 @@ adtteSpecInput <- function(inputId, # nolint
 #' @examples
 #' ui <- function(id,
 #'                data) {
+#'   checkmate::assert_class(data, "teal_data")
 #'   ns <- NS(id)
 #'
 #'   teal.widgets::standard_layout(
@@ -164,6 +165,8 @@ adtteSpecInput <- function(inputId, # nolint
 #' }
 #'
 #' server <- function(id, data, filter_panel_api) {
+#'   checkmate::assert_class(data, "reactive")
+#'   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 #'   moduleServer(id, function(input, output, session) {
 #'     experiment <- experimentSpecServer(
 #'       "experiment",

--- a/R/geneSpec.R
+++ b/R/geneSpec.R
@@ -222,6 +222,7 @@ h_parse_genes <- function(words, choices) {
 #' ui <- function(id,
 #'                data,
 #'                funs) {
+#'   checkmate::assert_class(data, "teal_data")
 #'   ns <- NS(id)
 #'   teal.widgets::standard_layout(
 #'     encoding = div(
@@ -237,6 +238,8 @@ h_parse_genes <- function(words, choices) {
 #' server <- function(id,
 #'                    data,
 #'                    funs) {
+#'   checkmate::assert_class(data, "reactive")
+#'   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 #'   moduleServer(id, function(input, output, session) {
 #'     gene_choices <- reactive({
 #'       mae <- data()[["MAE"]]

--- a/R/geneSpec.R
+++ b/R/geneSpec.R
@@ -239,7 +239,7 @@ h_parse_genes <- function(words, choices) {
 #'                    funs) {
 #'   moduleServer(id, function(input, output, session) {
 #'     gene_choices <- reactive({
-#'       mae <- data[["MAE"]]()
+#'       mae <- data()[["MAE"]]
 #'       object <- mae[[1]]
 #'       gene_ids <- rownames(object)
 #'       gene_names <- SummarizedExperiment::rowData(object)$symbol

--- a/R/sampleVarSpec.R
+++ b/R/sampleVarSpec.R
@@ -203,6 +203,7 @@ validate_n_levels <- function(x, name, n_levels) {
 #' @examples
 #' ui <- function(id,
 #'                data) {
+#'   checkmate::assert_class(data, "teal_data")
 #'   ns <- NS(id)
 #'   mae <- data[["MAE"]]
 #'   experiment_name_choices <- names(mae)
@@ -216,6 +217,8 @@ validate_n_levels <- function(x, name, n_levels) {
 #' }
 #' server <- function(id,
 #'                    data) {
+#'   checkmate::assert_class(data, "reactive")
+#'   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 #'   moduleServer(id, function(input, output, session) {
 #'     experiment_data <- reactive({
 #'       req(input$experiment_name)

--- a/R/sampleVarSpec.R
+++ b/R/sampleVarSpec.R
@@ -204,7 +204,7 @@ validate_n_levels <- function(x, name, n_levels) {
 #' ui <- function(id,
 #'                data) {
 #'   ns <- NS(id)
-#'   mae <- data[["MAE"]]()
+#'   mae <- data[["MAE"]]
 #'   experiment_name_choices <- names(mae)
 #'   teal.widgets::standard_layout(
 #'     encoding = div(
@@ -219,7 +219,7 @@ validate_n_levels <- function(x, name, n_levels) {
 #'   moduleServer(id, function(input, output, session) {
 #'     experiment_data <- reactive({
 #'       req(input$experiment_name)
-#'       mae <- data[["MAE"]]()
+#'       mae <- data()[["MAE"]]
 #'       object <- mae[[input$experiment_name]]
 #'       SummarizedExperiment::colData(object) <-
 #'         hermes::df_cols_to_factor(SummarizedExperiment::colData(object))

--- a/man/adtteSpecServer.Rd
+++ b/man/adtteSpecServer.Rd
@@ -81,7 +81,7 @@ ui <- function(id,
 
   teal.widgets::standard_layout(
     encoding = div(
-      experimentSpecInput(ns("experiment"), data = data, mae_name = "MAE"),
+      experimentSpecInput(ns("experiment"), data = reactive(data), mae_name = "MAE"),
       assaySpecInput(ns("assay")),
       geneSpecInput(ns("genes"), funs = list(Mean = colMeans)),
       adtteSpecInput(ns("adtte"))

--- a/man/geneSpecServer.Rd
+++ b/man/geneSpecServer.Rd
@@ -56,7 +56,7 @@ server <- function(id,
                    funs) {
   moduleServer(id, function(input, output, session) {
     gene_choices <- reactive({
-      mae <- data[["MAE"]]()
+      mae <- data()[["MAE"]]
       object <- mae[[1]]
       gene_ids <- rownames(object)
       gene_names <- SummarizedExperiment::rowData(object)$symbol

--- a/man/sampleVarSpecServer.Rd
+++ b/man/sampleVarSpecServer.Rd
@@ -61,7 +61,7 @@ If \code{num_levels} is specified then only factor columns will be available.
 ui <- function(id,
                data) {
   ns <- NS(id)
-  mae <- data[["MAE"]]()
+  mae <- data[["MAE"]]
   experiment_name_choices <- names(mae)
   teal.widgets::standard_layout(
     encoding = div(
@@ -76,7 +76,7 @@ server <- function(id,
   moduleServer(id, function(input, output, session) {
     experiment_data <- reactive({
       req(input$experiment_name)
-      mae <- data[["MAE"]]()
+      mae <- data()[["MAE"]]
       object <- mae[[input$experiment_name]]
       SummarizedExperiment::colData(object) <-
         hermes::df_cols_to_factor(SummarizedExperiment::colData(object))


### PR DESCRIPTION
Unblocks the PR #344 by updating examples with `tdata` -> `teal_data` changes

Please test examples from these modules:

### 1. geneSpec.R

<details>
  <summary>
  Example app
  </summary>

```r
ui <- function(id,
               data,
               funs) {
  checkmate::assert_class(data, "teal_data")
  ns <- NS(id)
  teal.widgets::standard_layout(
    encoding = div(
      geneSpecInput(
        ns("my_genes"),
        funs = funs,
        label_funs = "Please select function"
      )
    ),
    output = textOutput(ns("result"))
  )
}
server <- function(id,
                   data,
                   funs) {
  checkmate::assert_class(data, "reactive")
  checkmate::assert_class(shiny::isolate(data()), "teal_data")
  moduleServer(id, function(input, output, session) {
    gene_choices <- reactive({
      mae <- data()[["MAE"]]
      object <- mae[[1]]
      gene_ids <- rownames(object)
      gene_names <- SummarizedExperiment::rowData(object)$symbol
      gene_data <- data.frame(
        id = gene_ids,
        name = gene_names
      )
      gene_data[order(gene_data$name), ]
    })
    gene_spec <- geneSpecServer(
      "my_genes",
      funs = funs,
      gene_choices = gene_choices
    )
    output$result <- renderText({
      validate_gene_spec(
        gene_spec(),
        gene_choices()$id
      )
      gene_spec <- gene_spec()
      gene_spec$get_label()
    })
  })
}
funs <- list(mean = colMeans)
my_app <- function() {
  data <- teal_data(MAE = hermes::multi_assay_experiment)
  app <- init(
    data = data,
    modules = modules(
      module(
        label = "GeneSpec example",
        server = server,
        server_args = list(funs = funs),
        ui = ui,
        ui_args = list(funs = funs),
        datanames = "all"
      )
    )
  )
  shinyApp(app$ui, app$server)
}
if (interactive()) {
  my_app()
}
```
</details>

### 1. sampleVarSpec.R

<details>
  <summary>
  Example app
  </summary>

```r
ui <- function(id,
               data) {
  checkmate::assert_class(data, "teal_data")
  ns <- NS(id)
  mae <- data[["MAE"]]
  experiment_name_choices <- names(mae)
  teal.widgets::standard_layout(
    encoding = div(
      selectInput(ns("experiment_name"), "Select experiment", experiment_name_choices),
      sampleVarSpecInput(ns("facet_var"), "Select faceting variable")
    ),
    output = plotOutput(ns("plot"))
  )
}
server <- function(id,
                   data) {
  checkmate::assert_class(data, "reactive")
  checkmate::assert_class(shiny::isolate(data()), "teal_data")
  moduleServer(id, function(input, output, session) {
    experiment_data <- reactive({
      req(input$experiment_name)
      mae <- data()[["MAE"]]
      object <- mae[[input$experiment_name]]
      SummarizedExperiment::colData(object) <-
        hermes::df_cols_to_factor(SummarizedExperiment::colData(object))
      object
    })
    facet_var_spec <- sampleVarSpecServer(
      "facet_var",
      experiment_name = reactive({
        input$experiment_name
      }),
      original_data = experiment_data
    )
    output$plot <- renderPlot({
      experiment_data_final <- facet_var_spec$experiment_data()
      facet_var <- facet_var_spec$sample_var()
      hermes::draw_boxplot(
        experiment_data_final,
        assay_name = "counts",
        genes = hermes::gene_spec(hermes::genes(experiment_data_final)[1]),
        facet_var = facet_var
      )
    })
  })
}
my_app <- function() {
  data <- teal_data(MAE = hermes::multi_assay_experiment)
  app <- init(
    data = data,
    modules = modules(
      module(
        label = "sampleVarSpec example",
        server = server,
        ui = ui,
        datanames = "all"
      )
    )
  )
  shinyApp(app$ui, app$server)
}
if (interactive()) {
  my_app()
}
```
</details>
