### PR TITLE
Move the data dependant UI into server

### DIFF
--- a/R/adtteSpec.R
+++ b/R/adtteSpec.R
@@ -148,18 +148,11 @@ adtteSpecInput <- function(inputId, # nolint
 #' @export
 #'
 #' @examples
-#' ui <- function(id,
-#'                data) {
-#'   checkmate::assert_class(data, "teal_data")
+#' ui <- function(id) {
 #'   ns <- NS(id)
 #'
 #'   teal.widgets::standard_layout(
-#'     encoding = div(
-#'       experimentSpecInput(ns("experiment"), data = reactive(data), mae_name = "MAE"),
-#'       assaySpecInput(ns("assay")),
-#'       geneSpecInput(ns("genes"), funs = list(Mean = colMeans)),
-#'       adtteSpecInput(ns("adtte"))
-#'     ),
+#'     encoding = uiOutput(ns("encoding_ui")),
 #'     output = verbatimTextOutput(ns("summary"))
 #'   )
 #' }
@@ -168,6 +161,14 @@ adtteSpecInput <- function(inputId, # nolint
 #'   checkmate::assert_class(data, "reactive")
 #'   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 #'   moduleServer(id, function(input, output, session) {
+#'     output$asdf <- renderUI({
+#'       div(
+#'         experimentSpecInput(session$ns("experiment"), data, mae_name = "MAE"),
+#'         assaySpecInput(session$ns("assay")),
+#'         geneSpecInput(session$ns("genes"), funs = list(Mean = colMeans)),
+#'         adtteSpecInput(session$ns("adtte"))
+#'       )
+#'     })
 #'     experiment <- experimentSpecServer(
 #'       "experiment",
 #'       data = data,

--- a/R/assaySpec.R
+++ b/R/assaySpec.R
@@ -44,27 +44,25 @@ assaySpecInput <- function(inputId, # nolint
 #' @export
 #'
 #' @examples
-#' ui <- function(id,
-#'                data) {
+#' ui <- function(id) {
 #'   ns <- NS(id)
 #'   teal.widgets::standard_layout(
-#'     encoding = div(
-#'       experimentSpecInput(
-#'         ns("experiment"),
-#'         data,
-#'         "MAE"
-#'       ),
-#'       assaySpecInput(
-#'         ns("assay"),
-#'         label_assays = "Please choose assay"
-#'       )
-#'     ),
+#'     encoding = uiOutput(ns("encoding_ui")),
 #'     output = textOutput(ns("result"))
 #'   )
 #' }
 #'
 #' server <- function(id, data, filter_panel_api) {
 #'   moduleServer(id, module = function(input, output, session) {
+#'     output$encoding_ui <- renderUI({
+#'       div(
+#'         experimentSpecInput(session$ns("experiment"), data(), "MAE"),
+#'         assaySpecInput(
+#'           session$ns("assay"),
+#'           label_assays = "Please choose assay"
+#'         )
+#'       )
+#'     })
 #'     experiment <- experimentSpecServer(
 #'       id = "experiment",
 #'       data = data,

--- a/R/barplot.R
+++ b/R/barplot.R
@@ -66,12 +66,10 @@ tm_g_barplot <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_barplot <- function(id,
-                         data,
                          mae_name,
                          summary_funs,
                          pre_output,
                          post_output) {
-  checkmate::assert_class(data, "teal_data")
   ns <- NS(id)
   teal.widgets::standard_layout(
     encoding = div(
@@ -80,7 +78,7 @@ ui_g_barplot <- function(id,
       ###
       tags$label("Encodings", class = "text-primary"),
       helpText("Analysis of MAE:", tags$code(mae_name)),
-      experimentSpecInput(ns("experiment"), data, mae_name),
+      uiOutput(ns("experiment_ui")),
       assaySpecInput(ns("assay")),
       sampleVarSpecInput(ns("facet"), "Select Facet Variable"),
       geneSpecInput(ns("x"), summary_funs),
@@ -124,6 +122,9 @@ srv_g_barplot <- function(id,
   checkmate::assert_class(data, "reactive")
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment <- experimentSpecServer(
       "experiment",
       data = data,

--- a/R/boxplot.R
+++ b/R/boxplot.R
@@ -67,12 +67,10 @@ tm_g_boxplot <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_boxplot <- function(id,
-                         data,
                          mae_name,
                          summary_funs,
                          pre_output,
                          post_output) {
-  checkmate::assert_class(data, "teal_data")
   ns <- NS(id)
   teal.widgets::standard_layout(
     encoding = div(
@@ -81,7 +79,7 @@ ui_g_boxplot <- function(id,
       ###
       tags$label("Encodings", class = "text-primary"),
       helpText("Analysis of MAE:", tags$code(mae_name)),
-      experimentSpecInput(ns("experiment"), data, mae_name),
+      uiOutput(ns("experiment_ui")),
       assaySpecInput(ns("assay")),
       geneSpecInput(ns("genes"), summary_funs),
       tags$label("Jitter"),
@@ -121,6 +119,9 @@ srv_g_boxplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment <- experimentSpecServer(
       "experiment",
       data = data,

--- a/R/forestplot.R
+++ b/R/forestplot.R
@@ -92,13 +92,11 @@ tm_g_forest_tte <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_forest_tte <- function(id,
-                            data,
                             adtte_name,
                             mae_name,
                             summary_funs,
                             pre_output,
                             post_output) {
-  checkmate::assert_class(data, "teal_data")
   ns <- NS(id)
   teal.widgets::standard_layout(
     encoding = div(
@@ -107,7 +105,7 @@ ui_g_forest_tte <- function(id,
       ###
       tags$label("Encodings", class = "text-primary"),
       helpText("Analysis of MAE:", tags$code(mae_name)),
-      experimentSpecInput(ns("experiment"), data, mae_name),
+      uiOutput(ns("experiment_ui")),
       assaySpecInput(ns("assay")),
       geneSpecInput(ns("genes"), summary_funs),
       helpText("Analysis of ADTTE:", tags$code(adtte_name)),
@@ -148,6 +146,9 @@ srv_g_forest_tte <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment <- experimentSpecServer(
       "experiment",
       data = data,

--- a/R/geneSpec.R
+++ b/R/geneSpec.R
@@ -219,10 +219,7 @@ h_parse_genes <- function(words, choices) {
 #' @export
 #'
 #' @examples
-#' ui <- function(id,
-#'                data,
-#'                funs) {
-#'   checkmate::assert_class(data, "teal_data")
+#' ui <- function(id, funs) {
 #'   ns <- NS(id)
 #'   teal.widgets::standard_layout(
 #'     encoding = div(

--- a/R/km.R
+++ b/R/km.R
@@ -93,13 +93,11 @@ tm_g_km <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_km <- function(id,
-                    data,
                     adtte_name,
                     mae_name,
                     summary_funs,
                     pre_output,
                     post_output) {
-  checkmate::assert_class(data, "teal_data")
   ns <- NS(id)
   teal.widgets::standard_layout(
     encoding = div(
@@ -108,7 +106,7 @@ ui_g_km <- function(id,
       ###
       tags$label("Encodings", class = "text-primary"),
       helpText("Analysis of MAE:", tags$code(mae_name)),
-      experimentSpecInput(ns("experiment"), data, mae_name),
+      uiOutput(ns("experiment_ui")),
       assaySpecInput(ns("assay")),
       geneSpecInput(ns("genes"), summary_funs),
       helpText("Analysis of ADTTE:", tags$code(adtte_name)),
@@ -153,6 +151,9 @@ srv_g_km <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment <- experimentSpecServer(
       "experiment",
       data = data,

--- a/R/pca.R
+++ b/R/pca.R
@@ -57,14 +57,10 @@ tm_g_pca <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_pca <- function(id,
-                     data,
                      mae_name,
                      pre_output,
                      post_output) {
-  checkmate::assert_class(data, "teal_data")
   ns <- NS(id)
-  mae <- data[[mae_name]]
-  experiment_name_choices <- names(mae)
 
   tagList(
     teal.widgets::standard_layout(
@@ -75,7 +71,7 @@ ui_g_pca <- function(id,
         ###
         tags$label("Encodings", class = "text-primary"),
         helpText("Analysis of MAE:", tags$code(mae_name)),
-        experimentSpecInput(ns("experiment"), data, mae_name),
+        uiOutput(ns("experiment_ui")),
         assaySpecInput(ns("assay")),
         conditionalPanel(
           condition = "input.tab_selected == 'PCA'",
@@ -165,6 +161,9 @@ srv_g_pca <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment <- experimentSpecServer(
       "experiment",
       data = data,

--- a/R/quality.R
+++ b/R/quality.R
@@ -111,11 +111,9 @@ tm_g_quality <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_quality <- function(id,
-                         data,
                          mae_name,
                          pre_output,
                          post_output) {
-  checkmate::assert_class(data, "teal_data")
   ns <- NS(id)
   teal.widgets::standard_layout(
     encoding = div(
@@ -124,7 +122,7 @@ ui_g_quality <- function(id,
       ###
       tags$label("Encodings", class = "text-primary"),
       helpText("Analysis of MAE:", tags$code(mae_name)),
-      experimentSpecInput(ns("experiment"), data, mae_name),
+      uiOutput(ns("experiment_ui")),
       selectInput(
         ns("plot_type"),
         "Plot Type",
@@ -205,6 +203,9 @@ srv_g_quality <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment <- experimentSpecServer(
       "experiment",
       data = data,

--- a/R/sampleVarSpec.R
+++ b/R/sampleVarSpec.R
@@ -201,17 +201,12 @@ validate_n_levels <- function(x, name, n_levels) {
 #' @export
 #'
 #' @examples
-#' ui <- function(id,
-#'                data) {
+#' ui <- function(id) {
 #'   checkmate::assert_class(data, "teal_data")
 #'   ns <- NS(id)
-#'   mae <- data[["MAE"]]
-#'   experiment_name_choices <- names(mae)
+#'
 #'   teal.widgets::standard_layout(
-#'     encoding = div(
-#'       selectInput(ns("experiment_name"), "Select experiment", experiment_name_choices),
-#'       sampleVarSpecInput(ns("facet_var"), "Select faceting variable")
-#'     ),
+#'     encoding = uiOutput(ns("encoding_ui")),
 #'     output = plotOutput(ns("plot"))
 #'   )
 #' }
@@ -220,6 +215,14 @@ validate_n_levels <- function(x, name, n_levels) {
 #'   checkmate::assert_class(data, "reactive")
 #'   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 #'   moduleServer(id, function(input, output, session) {
+#'     output$encoding_ui <- renderUI({
+#'       mae <- data()[["MAE"]]
+#'       experiment_name_choices <- names(mae)
+#'       div(
+#'         selectInput(session$ns("experiment_name"), "Select experiment", experiment_name_choices),
+#'         sampleVarSpecInput(session$ns("facet_var"), "Select faceting variable")
+#'       )
+#'     })
 #'     experiment_data <- reactive({
 #'       req(input$experiment_name)
 #'       mae <- data()[["MAE"]]

--- a/R/scatterplot.R
+++ b/R/scatterplot.R
@@ -66,12 +66,10 @@ tm_g_scatterplot <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_scatterplot <- function(id,
-                             data,
                              mae_name,
                              summary_funs,
                              pre_output,
                              post_output) {
-  checkmate::assert_class(data, "teal_data")
   ns <- NS(id)
 
   smooth_method_choices <- c(
@@ -87,7 +85,7 @@ ui_g_scatterplot <- function(id,
       ###
       tags$label("Encodings", class = "text-primary"),
       helpText("Analysis of MAE:", tags$code(mae_name)),
-      experimentSpecInput(ns("experiment"), data, mae_name),
+      uiOutput(ns("experiment_ui")),
       assaySpecInput(ns("assay")),
       geneSpecInput(ns("x_spec"), summary_funs, label_genes = "Select x Gene(s)"),
       geneSpecInput(ns("y_spec"), summary_funs, label_genes = "Select y Gene(s)"),
@@ -124,6 +122,9 @@ srv_g_scatterplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment <- experimentSpecServer(
       "experiment",
       data = data,

--- a/R/volcanoplot.R
+++ b/R/volcanoplot.R
@@ -58,12 +58,10 @@ tm_g_volcanoplot <- function(label,
 #' @inheritParams module_arguments
 #' @export
 ui_g_volcanoplot <- function(id,
-                             data,
                              mae_name,
                              pre_output,
                              post_output) {
   ns <- NS(id)
-  mae <- data[[mae_name]]
 
   teal.widgets::standard_layout(
     output = div(
@@ -78,7 +76,7 @@ ui_g_volcanoplot <- function(id,
       ###
       tags$label("Encodings", class = "text-primary"),
       helpText("Analysis of MAE:", tags$code(mae_name)),
-      experimentSpecInput(ns("experiment"), data, mae_name),
+      uiOutput(ns("experiment_ui")),
       assaySpecInput(ns("assay")),
       sampleVarSpecInput(ns("compare_group"), "Compare Groups", "Please group here into 2 levels"),
       tags$label("Show Top Differentiated Genes"),
@@ -112,6 +110,9 @@ srv_g_volcanoplot <- function(id,
   checkmate::assert_class(shiny::isolate(data()), "teal_data")
 
   moduleServer(id, function(input, output, session) {
+    output$experiment_ui <- renderUI({
+      experimentSpecInput(session$ns("experiment"), data(), mae_name)
+    })
     experiment_data <- experimentSpecServer(
       "experiment",
       data = data,


### PR DESCRIPTION
Remove the use of `data` in the UI function of teal modules as it was deprecated since [b617482b](https://github.com/insightsengineering/teal/commit/b617482b00c3efe069ee5e26addd9f5f80e5d325) 