### PR TITLE
Closes #374 remove all references to `scda`

### DIFF
--- a/data-raw/data.R
+++ b/data-raw/data.R
@@ -1,5 +1,5 @@
 ## code to prepare `data` for testing examples
-library(scda)
+library(random.cdisc.data)
 
-rADTTE <- synthetic_cdisc_data("latest")$adtte # nolint
+rADTTE <- random.cdisc.data::cadtte
 usethis::use_data(rADTTE)


### PR DESCRIPTION
Swaps out the call to `library(scda)` for `library(random.cdisc.data)` and brings for the `ADTTE` object as appropriate from rcd as well