### PR TITLE
add idling time

### DIFF
--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -1,8 +1,10 @@
+Bové
 Forkers
 Hoffmann
 Lyndsee
 Midori
 RNAseq
+Sabanés
 UI
 funder
 hermes

--- a/tests/testthat/test-adtteSpec.R
+++ b/tests/testthat/test-adtteSpec.R
@@ -226,7 +226,7 @@ test_that("adtteSpecServer module works as expected in the test app", {
   app$set_inputs(!!ns2("add-ADTTE-filter-var_to_add") := "PARAMCD")
   app$set_inputs(!!ns2("active-ADTTE-filter-ADTTE_PARAMCD-inputs-selection") := "OS")
 
-  app$wait_for_idle()
+  app$wait_for_idle(timeout = 20000)
   # We expect to get a validation message (also a notification box but we cannot test that)
   res <- app$get_value(output = ns("summary"))
   expect_equal(res$message, "please select an endpoint")

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -214,7 +214,7 @@ test_that("pca module works as expected in the test app", {
 
   # Change to another experiment and check that it did not change.
   app$set_inputs(!!ns("experiment-name") := "hd2")
-  app$wait_for_idle()
+  app$wait_for_idle(timeout = 20000)
 
   res <- app$get_value(input = ns("n_top"))
   expect_identical(res, 777L)

--- a/tests/testthat/test-scatterplot.R
+++ b/tests/testthat/test-scatterplot.R
@@ -68,6 +68,7 @@ test_that("scatterplot module works as expected in the test app", {
   app$set_inputs(!!ns2("add-MAE-subjects-var_to_add") := "SEX")
   app$set_inputs(!!ns2("active-MAE-subjects-MAE_SEX-inputs-selection") := "F")
 
+  app$wait_for_idle()
   res <- app$get_value(input = ns("x_spec-genes"))
   expect_identical(res, "GeneID:503538")
   res <- app$wait_for_value(input = ns("y_spec-genes"))


### PR DESCRIPTION
Increase timeout

```
══ Failed tests ════════════════════════════════════════════════════════════════
  ── Error ('test-adtteSpec.R:229:3'): adtteSpecServer module works as expected in the test app ──
  Error in `app_wait_for_idle(self, private, duration = duration, timeout = timeout)`: An error occurred while waiting for Shiny to be stable
  Backtrace:
      ▆
   1. └─app$wait_for_idle() at test-adtteSpec.R:229:3
   2.   └─shinytest2:::app_wait_for_idle(self, private, duration = duration, timeout = timeout)
   3.     └─shinytest2:::app_abort(self, private, "An error occurred while waiting for Shiny to be stable")
   4.       └─rlang::abort(..., app = self, call = call)
  ── Failure ('test-assaySpec.R:39:3'): assaySpecServer module works as expected in the test app ──
  res$message (`actual`) not identical to "No assays eligible for this experiment, please make sure to add normalized assays" (`expected`).
  
  `actual` is NULL
  `expected` is a character vector ('No assays eligible for this experiment, please make sure to add normalized assays')
  ── Failure ('test-assaySpec.R:46:3'): assaySpecServer module works as expected in the test app ──
  `res` (`actual`) not identical to "rpkm" (`expected`).
  
  `actual` is NULL
  `expected` is a character vector ('rpkm')
  ── Failure ('test-assaySpec.R:49:3'): assaySpecServer module works as expected in the test app ──
  `res` (`actual`) not identical to "[1] \"rpkm\"" (`expected`).
  
  `actual` is NULL
  `expected` is a character vector ('[1] "rpkm"')
  ── Failure ('test-assaySpec.R:54:3'): assaySpecServer module works as expected in the test app ──
  `res` (`actual`) not identical to "[1] \"voom\"" (`expected`).
  
  `actual` is NULL
  `expected` is a character vector ('[1] "voom"')
  ── Failure ('test-assaySpec.R:60:3'): assaySpecServer module works as expected in the test app ──
  `res` (`actual`) not identical to "[1] \"\"" (`expected`).
  
  `actual` is NULL
  `expected` is a character vector ('[1] ""')
  ── Error ('test-pca.R:66:3'): pca module works as expected in the test app ─────
  Error in `app_wait_for_idle(self, private, duration = duration, timeout = timeout)`: An error occurred while waiting for Shiny to be stable
  Backtrace:
      ▆
   1. └─app$wait_for_idle() at test-pca.R:66:3
   2.   └─shinytest2:::app_wait_for_idle(self, private, duration = duration, timeout = timeout)
   3.     └─shinytest2:::app_abort(self, private, "An error occurred while waiting for Shiny to be stable")
   4.       └─rlang::abort(..., app = self, call = call)
  ── Failure ('test-scatterplot.R:72:3'): scatterplot module works as expected in the test app ──
  `res` (`actual`) not identical to "GeneID:503538" (`expected`).
  
  `actual` is NULL
  `expected` is a character vector ('GeneID:503538')
  ── Error ('test-scatterplot.R:78:3'): scatterplot module works as expected in the test app ──
  Error in `app_wait_for_idle(self, private, duration = duration, timeout = timeout)`: An error occurred while waiting for Shiny to be stable
  Backtrace:
      ▆
   1. └─app$wait_for_idle() at test-scatterplot.R:78:3
   2.   └─shinytest2:::app_wait_for_idle(self, private, duration = duration, timeout = timeout)
   3.     └─shinytest2:::app_abort(self, private, "An error occurred while waiting for Shiny to be stable")
   4.       └─rlang::abort(..., app = self, call = call)
  
  [ FAIL 9 | WARN 0 | SKIP 0 | PASS 171 ]
```
