### PR TITLE
Fix integration test failures

### DIFF
--- a/tests/testthat/test-assaySpec.R
+++ b/tests/testthat/test-assaySpec.R
@@ -31,10 +31,11 @@ test_that("assaySpecServer module works as expected in the test app", {
     load_timeout = 300000
   )
 
+  app$wait_for_idle(timeout = 20000)
+
   ns <- module_ns_shiny2(app)
 
   # Validation message because no assays eligible in first experiment.
-  app$wait_for_idle(timeout = 20000)
   res <- app$get_value(output = ns("result"))
   expect_identical(res$message, "No assays eligible for this experiment, please make sure to add normalized assays")
 


### PR DESCRIPTION
Changes:
1. Wait for app idle before getting the namespace (in `test-assaySpec.R`) so we don't try to find shiny inputs with ids like `NA-module-assay-name`.

The integration tests for `teal.modules.hermes` fails with these test logs:

```r
Loading required package: ggplot2
Loading required package: shiny
Loading required package: teal
Loading required package: teal.data
Loading required package: teal.code
Loading required package: teal.slice

You are using teal version 0.15.2.9045

Attaching package: 'teal'

The following objects are masked from 'package:teal.slice':

    as.teal_slices, teal_slices


Attaching package: 'teal.modules.hermes'

The following object is masked from 'package:teal':

    validate_n_levels

The following object is masked from 'package:teal.data':

    rADTTE

> testthat::test_check(pkg_name)
Error received while setting inputs: Unable to find input binding for element with id NA-module-experiment-name
    x
 1. \-app$set_inputs(`:=`(!!ns("experiment-name"), "hd2")) at test-assaySpec.R:42:3
 2.   \-shinytest2:::app_set_inputs(...)
Error received while setting inputs: Unable to find input binding for element with id NA-module-assay-name
    x
 1. \-app$set_inputs(`:=`(!!ns("assay-name"), "voom")) at test-assaySpec.R:51:3
 2.   \-shinytest2:::app_set_inputs(...)
Error received while setting inputs: Unable to find input binding for element with id NA-module-assay-name
    x
 1. \-app$set_inputs(`:=`(!!ns("assay-name"), "cpm")) at test-assaySpec.R:57:3
 2.   \-shinytest2:::app_set_inputs(...)
set_inputs(app$set_inputs(`:=`(!!ns("experiment-name"), "hd2"))): Server did not update any output values within 4 seconds. If this is expected, use `wait_ = FALSE` or increase the value of `timeout_`.
    x
 1. \-app$set_inputs(`:=`(!!ns("experiment-name"), "hd2")) at test-scatterplot.R:87:3
 2.   \-shinytest2:::app_set_inputs(...)
[ FAIL 5 | WARN 0 | SKIP 0 | PASS 205 ]

══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-assaySpec.R:39:3'): assaySpecServer module works as expected in the test app ──
res$message (`actual`) not identical to "No assays eligible for this experiment, please make sure to add normalized assays" (`expected`).

`actual` is NULL
`expected` is a character vector ('No assays eligible for this experiment, please make sure to add normalized assays')
── Failure ('test-assaySpec.R:46:3'): assaySpecServer module works as expected in the test app ──
`res` (`actual`) not identical to "rpkm" (`expected`).

`actual` is NULL
`expected` is a character vector ('rpkm')
── Failure ('test-assaySpec.R:49:3'): assaySpecServer module works as expected in the test app ──
`res` (`actual`) not identical to "[1] \"rpkm\"" (`expected`).

`actual` is NULL
`expected` is a character vector ('[1] "rpkm"')
── Failure ('test-assaySpec.R:54:3'): assaySpecServer module works as expected in the test app ──
`res` (`actual`) not identical to "[1] \"voom\"" (`expected`).

`actual` is NULL
`expected` is a character vector ('[1] "voom"')
── Failure ('test-assaySpec.R:60:3'): assaySpecServer module works as expected in the test app ──
`res` (`actual`) not identical to "[1] \"\"" (`expected`).

`actual` is NULL
`expected` is a character vector ('[1] ""')

[ FAIL 5 | WARN 0 | SKIP 0 | PASS 205 ]
```