### PR TITLE
Remove lookup-refs, vbump dependencies + add Remotes

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -30,19 +30,6 @@ jobs:
         _R_CHECK_EXAMPLE_TIMING_THRESHOLD_=10
       additional-r-cmd-check-params: --as-cran
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   r-cmd-non-cran:
     name: R CMD Check (non-CRAN) 🧬
     uses: insightsengineering/r.pkg.template/.github/workflows/build-check-install.yaml@main
@@ -55,19 +42,6 @@ jobs:
       concurrency-group: non-cran
       unit-test-report-directory: unit-test-report-non-cran
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   coverage:
     name: Coverage 📔
     uses: insightsengineering/r.pkg.template/.github/workflows/test-coverage.yaml@main
@@ -77,19 +51,6 @@ jobs:
       additional-env-vars: |
         NOT_CRAN=true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   linter:
     if: github.event_name != 'push'
     name: SuperLinter 🦸‍♀️
@@ -102,19 +63,6 @@ jobs:
     with:
       auto-update: true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   gitleaks:
     name: gitleaks 💧
     uses: insightsengineering/r.pkg.template/.github/workflows/gitleaks.yaml@main

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -43,16 +43,3 @@ jobs:
       default-landing-page: latest-tag
       additional-unit-test-report-directories: unit-test-report-non-cran
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,19 +18,6 @@ jobs:
       skip-r-cmd-check: true
       skip-r-cmd-install: true
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   docs:
     name: Pkgdown Docs 📚
     needs: release
@@ -40,19 +27,6 @@ jobs:
     with:
       default-landing-page: latest-tag
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   validation:
     name: R Package Validation report 📃
     needs: release
@@ -61,19 +35,6 @@ jobs:
       REPO_GITHUB_TOKEN: ${{ secrets.REPO_GITHUB_TOKEN }}
     with:
       deps-installation-method: setup-r-dependencies
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   release:
     name: Create release 🎉
     uses: insightsengineering/r.pkg.template/.github/workflows/release.yaml@main

--- a/.github/workflows/scheduled.yaml
+++ b/.github/workflows/scheduled.yaml
@@ -58,20 +58,6 @@ jobs:
       )
     name: revdepcheck ↩️
     uses: insightsengineering/r.pkg.template/.github/workflows/revdepcheck.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice
   rhub:
     if: >
       github.event_name == 'schedule' || (
@@ -80,17 +66,3 @@ jobs:
       )
     name: R-hub 🌐
     uses: insightsengineering/r.pkg.template/.github/workflows/rhub.yaml@main
-    with:
-      lookup-refs: |
-        insightsengineering/formatters
-        insightsengineering/rtables
-        insightsengineering/rtables.officer
-        insightsengineering/hermes
-        insightsengineering/teal
-        insightsengineering/teal.transform
-        insightsengineering/teal.code
-        insightsengineering/teal.data
-        insightsengineering/teal.logger
-        insightsengineering/teal.reporter
-        insightsengineering/teal.widgets
-        insightsengineering/teal.slice

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -49,9 +49,9 @@ Imports:
     stats,
     stringr,
     SummarizedExperiment (>= 1.36.0),
-    teal.data (>= 0.6.0.9025),
-    teal.logger (>= 0.3.0.9004),
-    teal.reporter (>= 0.3.1.9023),
+    teal.data (>= 0.7.0),
+    teal.logger (>= 0.3.1),
+    teal.reporter (>= 0.4.0),
     teal.widgets (>= 0.4.2.9025),
     tern (>= 0.9.7),
     utils
@@ -73,6 +73,10 @@ VignetteBuilder:
 RdMacros:
     lifecycle
 biocViews:
+Remotes:
+    insightsengineering/hermes,
+    insightsengineering/teal,
+    insightsengineering/teal.widgets
 Config/Needs/verdepcheck: tidyverse/ggplot2, rstudio/shiny,
     insightsengineering/teal, insightsengineering/teal.slice,
     insightsengineering/teal.code, insightsengineering/teal.transform,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -52,7 +52,7 @@ Imports:
     teal.data (>= 0.7.0),
     teal.logger (>= 0.3.1),
     teal.reporter (>= 0.4.0),
-    teal.widgets (>= 0.4.2.9025),
+    teal.widgets (>= 0.4.3),
     tern (>= 0.9.7),
     utils
 Suggests:
@@ -75,8 +75,7 @@ RdMacros:
 biocViews:
 Remotes:
     insightsengineering/hermes,
-    insightsengineering/teal,
-    insightsengineering/teal.widgets
+    insightsengineering/teal
 Config/Needs/verdepcheck: tidyverse/ggplot2, rstudio/shiny,
     insightsengineering/teal, insightsengineering/teal.slice,
     insightsengineering/teal.code, insightsengineering/teal.transform,


### PR DESCRIPTION
Part of https://github.com/insightsengineering/coredev-tasks/issues/609

From now on, we will provide development dependencies in 
```
Remotes: repo/project@branch
```
format, so it's explicitly visible in the DESCRIPTION file and can be handled by `pak::install`, `renv::install` and `remotes::install`.

With development dependencies specified in CJ Pipelines configuration, this connection was hidden, and it was hard to install the package from the main branch (or any other branch) locally from user's machine.