### PR TITLE
Add getting started to navbar so it can be accessed

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,12 +5,19 @@ template:
   package: nesttemplate
 
 navbar:
+  components:
+    get-started:
+      text: Get started
+      href: articles/Getting_Started.html
+  structure:
+    left: [get-started, reference, articles, news]
   right:
     - icon: fa-github
       href: https://github.com/insightsengineering/teal.modules.hermes
 
 articles:
-  - title: All vignettes
+  - title: Get started
+    navbar: Get started
     contents:
       - Getting_Started
 


### PR DESCRIPTION
Part of vignette review https://github.com/insightsengineering/nestdevs-tasks/issues/99


Currently the navbar [does not contain "Get started"](https://insightsengineering.github.io/teal.modules.hermes/main/) like our other pkgdown sites. And this PR adds it.