### PR TITLE
chore: bump teal.logger dependency to 0.4.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     stringr,
     SummarizedExperiment (>= 1.36.0),
     teal.data (>= 0.7.0),
-    teal.logger (>= 0.3.2),
+    teal.logger (>= 0.4.0),
     teal.reporter (>= 0.4.0.9004),
     teal.widgets (>= 0.4.3.9001),
     tern (>= 0.9.7),


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.logger (>= 0.4.0) and removes it from Remotes.