### PR TITLE
Bump version of shiny to support `bslib` and align with `teal`'s min `shiny` version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ BugReports:
 Depends:
     ggplot2,
     R (>= 4.1),
-    shiny,
+    shiny (>= 1.8.1),
     teal (>= 0.16.0.9003)
 Imports:
     bslib,


### PR DESCRIPTION
Bump shiny version as per the discussion https://github.com/insightsengineering/teal.widgets/pull/312#discussion_r2250985703