### PR TITLE
Fix deep tests

### DIFF
--- a/.lintr
+++ b/.lintr
@@ -1,5 +1,5 @@
 linters: linters_with_defaults(
   line_length_linter = line_length_linter(120),
-  cyclocomp_linter = NULL,
+  pipe_consistency_linter = NULL,
   object_usage_linter = NULL
   )

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -93,4 +93,4 @@ Encoding: UTF-8
 Language: en-US
 LazyData: true
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3

--- a/R/adtteSpec.R
+++ b/R/adtteSpec.R
@@ -101,7 +101,7 @@ h_km_mae_to_adtte <- function(adtte,
 #' @return The UI part.
 #' @seealso [adtteSpecServer()] for the module server and a complete example.
 #' @export
-adtteSpecInput <- function(inputId, # nolint
+adtteSpecInput <- function(inputId, # nolint: object_name_linter.
                            label_paramcd = "Select Endpoint") {
   assert_string(inputId)
   assert_string(label_paramcd, min.chars = 1L)
@@ -240,7 +240,7 @@ adtteSpecInput <- function(inputId, # nolint
 #' if (interactive()) {
 #'   my_app()
 #' }
-adtteSpecServer <- function(id, # nolint
+adtteSpecServer <- function(id, # nolint: object_name_linter.
                             data,
                             mae_name,
                             adtte_name,

--- a/R/assaySpec.R
+++ b/R/assaySpec.R
@@ -10,7 +10,7 @@
 #' @return The UI part.
 #' @seealso [assaySpecServer()] for the module server and a complete example.
 #' @export
-assaySpecInput <- function(inputId, # nolint
+assaySpecInput <- function(inputId, # nolint: object_name_linter.
                            label_assays = "Select Assay") {
   assert_string(inputId)
   assert_string(label_assays, min.chars = 1L)
@@ -97,7 +97,7 @@ assaySpecInput <- function(inputId, # nolint
 #' if (interactive()) {
 #'   my_app()
 #' }
-assaySpecServer <- function(id, # nolint
+assaySpecServer <- function(id, # nolint: object_name_linter.
                             assays,
                             exclude_assays = character()) {
   assert_string(id)

--- a/R/checkmate.R
+++ b/R/checkmate.R
@@ -37,13 +37,13 @@ NULL
 #' @examples
 #' check_tag("bla")
 #' check_tag(NULL, null.ok = TRUE)
-check_tag <- function(x, null.ok = FALSE) { # nolint
+check_tag <- function(x, null.ok = FALSE) { # nolint: object_name_linter.
   assert_flag(null.ok)
   ok <- (null.ok && test_null(x)) || test_class(x, "shiny.tag") || test_class(x, "shiny.tag.list")
   if (!ok) {
     return("Must be a 'shiny.tag' or NULL")
   }
-  return(TRUE)
+  TRUE
 }
 
 #' @rdname check_tag
@@ -106,7 +106,7 @@ test_reactive <- makeTestFunction(check_reactive)
 #'
 #' @examples
 #' assert_summary_funs(list(mean = colMeans, raw = NULL), null.ok = TRUE)
-assert_summary_funs <- function(x, null.ok = FALSE) { # nolint
+assert_summary_funs <- function(x, null.ok = FALSE) { # nolint: object_name_linter.
   assert_flag(null.ok)
   assert_list(
     x,

--- a/R/experimentSpec.R
+++ b/R/experimentSpec.R
@@ -10,7 +10,7 @@
 #' @return The UI part.
 #' @seealso [experimentSpecServer()] for the module server and a complete example.
 #' @export
-experimentSpecInput <- function(inputId, # nolint
+experimentSpecInput <- function(inputId, # nolint: object_name_linter.
                                 data,
                                 mae_name,
                                 label_experiments = "Select Experiment") {
@@ -205,7 +205,7 @@ h_gene_data <- function(object, name_annotation) {
 #' if (interactive()) {
 #'   my_app()
 #' }
-experimentSpecServer <- function(id, # nolint
+experimentSpecServer <- function(id, # nolint: object_name_linter.
                                  data,
                                  filter_panel_api,
                                  mae_name,
@@ -277,7 +277,7 @@ experimentSpecServer <- function(id, # nolint
       data = data_return,
       name = reactive({
         input$name
-      }), # nolint
+      }),
       genes = genes,
       assays = assays
     )

--- a/R/geneSpec.R
+++ b/R/geneSpec.R
@@ -23,7 +23,7 @@
 #'
 #' @examples
 #' geneSpecInput("my_genes", list(mean = colMeans), label_funs = "Please select function")
-geneSpecInput <- function(inputId, # nolint
+geneSpecInput <- function(inputId, # nolint: object_name_linter.
                           funs,
                           label_genes = "Select Gene(s)",
                           label_funs = "Select Gene Summary",
@@ -148,7 +148,7 @@ geneSpecInput <- function(inputId, # nolint
 #'
 #' @export
 h_update_gene_selection <- function(session,
-                                    inputId, # nolint
+                                    inputId, # nolint: object_name_linter.
                                     selected,
                                     choices) {
   is_new_selected <- selected %in% choices$id
@@ -285,7 +285,7 @@ h_parse_genes <- function(words, choices) {
 #' if (interactive()) {
 #'   my_app()
 #' }
-geneSpecServer <- function(id, # nolint
+geneSpecServer <- function(id, # nolint: object_name_linter.
                            funs,
                            gene_choices,
                            label_modal_title = "Enter list of genes",
@@ -378,7 +378,7 @@ geneSpecServer <- function(id, # nolint
     })
 
     # Return the UI for a modal dialog with gene text input, showing examples.
-    dataModal <- function(example_list) { # nolint
+    dataModal <- function(example_list) { # nolint: object_name_linter.
       modalDialog(
         textInput(
           session$ns("gene_text"),

--- a/R/sampleVarSpec.R
+++ b/R/sampleVarSpec.R
@@ -14,7 +14,7 @@
 #'
 #' @examples
 #' sampleVarSpecInput("my_vars", label_vars = "Select faceting variable")
-sampleVarSpecInput <- function(inputId, # nolint
+sampleVarSpecInput <- function(inputId, # nolint: object_name_linter.
                                label_vars = "Select sample variable",
                                label_levels_button = "Combine factor levels") {
   assert_string(inputId)
@@ -261,7 +261,7 @@ validate_n_levels <- function(x, name, n_levels) {
 #' if (interactive()) {
 #'   my_app()
 #' }
-sampleVarSpecServer <- function(id, # nolint
+sampleVarSpecServer <- function(id, # nolint: object_name_linter.
                                 experiment_name,
                                 original_data,
                                 transformed_data = original_data,
@@ -366,7 +366,7 @@ sampleVarSpecServer <- function(id, # nolint
 
     # Function to return the UI for a modal dialog with matrix input for combination
     # assignment.
-    combModal <- function(sample_var_levels, # nolint
+    combModal <- function(sample_var_levels, # nolint: object_name_linter.
                           n_max_groups,
                           selected_groups) {
       if (is.null(selected_groups)) {
@@ -416,9 +416,9 @@ sampleVarSpecServer <- function(id, # nolint
 
           old_values <- names(assign_lists[[experiment_name]][[sample_var]])
           if (!is.null(old_values) &&
-            length(old_values) == length(sample_var_levels) && # nolint
-            all(sort(old_values) == sort(sample_var_levels))) { # nolint
-            selected_groups <- assign_lists[[experiment_name]][[sample_var]] # nolint
+              length(old_values) == length(sample_var_levels) && #nolint indentation_linter
+              all(sort(old_values) == sort(sample_var_levels))) {
+            selected_groups <- assign_lists[[experiment_name]][[sample_var]]
           }
 
           showModal(combModal(
@@ -490,14 +490,14 @@ sampleVarSpecServer <- function(id, # nolint
 #'   experiment_name = reactive({
 #'     input$experiment_name
 #'   }),
-#'   original_data = ori_data # nolint Please update the <ori_data>
+#'   original_data = ori_data # Please update the <ori_data>
 #' )
 #' # Then can extract the transformed data and selected variables later:
 #' experiment_data <- sample_var_specs$experiment_data()
 #' facet_var <- sample_var_specs$vars$facet_var()
 #' color_var <- sample_var_specs$vars$color_var()
 #' }
-multiSampleVarSpecServer <- function(inputIds, # nolint
+multiSampleVarSpecServer <- function(inputIds, # nolint: object_name_linter.
                                      original_data,
                                      ...) {
   assert_character(inputIds, any.missing = FALSE, unique = TRUE)

--- a/R/sampleVarSpec.R
+++ b/R/sampleVarSpec.R
@@ -416,7 +416,7 @@ sampleVarSpecServer <- function(id, # nolint: object_name_linter.
 
           old_values <- names(assign_lists[[experiment_name]][[sample_var]])
           if (!is.null(old_values) &&
-            length(old_values) == length(sample_var_levels) && # nolint indentation_linter
+            length(old_values) == length(sample_var_levels) && # nolint: indentation_linter.
             all(sort(old_values) == sort(sample_var_levels))) {
             selected_groups <- assign_lists[[experiment_name]][[sample_var]]
           }

--- a/R/sampleVarSpec.R
+++ b/R/sampleVarSpec.R
@@ -416,8 +416,8 @@ sampleVarSpecServer <- function(id, # nolint: object_name_linter.
 
           old_values <- names(assign_lists[[experiment_name]][[sample_var]])
           if (!is.null(old_values) &&
-              length(old_values) == length(sample_var_levels) && #nolint indentation_linter
-              all(sort(old_values) == sort(sample_var_levels))) {
+            length(old_values) == length(sample_var_levels) && # nolint indentation_linter
+            all(sort(old_values) == sort(sample_var_levels))) {
             selected_groups <- assign_lists[[experiment_name]][[sample_var]]
           }
 

--- a/R/tm_g_barplot.R
+++ b/R/tm_g_barplot.R
@@ -272,7 +272,7 @@ srv_g_barplot <- function(id,
 sample_tm_g_barplot <- function(.test = FALSE) {
   data <- within(
     teal.data::teal_data(),
-    object_name_linterMAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   )
   app <- teal::init(
     data = data,

--- a/R/tm_g_barplot.R
+++ b/R/tm_g_barplot.R
@@ -272,7 +272,7 @@ srv_g_barplot <- function(id,
 sample_tm_g_barplot <- function(.test = FALSE) {
   data <- within(
     teal.data::teal_data(),
-    MAE <- hermes::multi_assay_experiment # nolint
+    object_name_linterMAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   )
   app <- teal::init(
     data = data,

--- a/R/tm_g_boxplot.R
+++ b/R/tm_g_boxplot.R
@@ -284,7 +284,7 @@ srv_g_boxplot <- function(id,
 sample_tm_g_boxplot <- function(.test = FALSE) {
   data <- within(
     teal.data::teal_data(),
-    MAE <- hermes::multi_assay_experiment # nolint
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   )
   app <- teal::init(
     data = data,

--- a/R/tm_g_forest_tte.R
+++ b/R/tm_g_forest_tte.R
@@ -306,11 +306,11 @@ srv_g_forest_tte <- function(id,
 #' if (interactive()) {
 #'   sample_tm_g_forest_tte()
 #' }
-sample_tm_g_forest_tte <- function(.test = FALSE) { # nolint
+sample_tm_g_forest_tte <- function(.test = FALSE) {
   data <- within(teal.data::teal_data(), {
-    ADTTE <- teal.data::rADTTE |> # nolint
+    ADTTE <- teal.data::rADTTE |> # nolint: object_name_linter.
       dplyr::mutate(is_event = .data$CNSR == 0)
-    MAE <- hermes::multi_assay_experiment # nolint
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   })
   join_keys(data)["ADTTE", "ADTTE"] <- c("STUDYID", "USUBJID", "PARAMCD")
 

--- a/R/tm_g_km.R
+++ b/R/tm_g_km.R
@@ -302,11 +302,11 @@ srv_g_km <- function(id,
 #' if (interactive()) {
 #'   sample_tm_g_km()
 #' }
-sample_tm_g_km <- function(.test = FALSE) { # nolint
+sample_tm_g_km <- function(.test = FALSE) { # nolint: object_name_linter.
   data <- within(teal.data::teal_data(), {
-    ADTTE <- teal.data::rADTTE |> # nolint
+    ADTTE <- teal.data::rADTTE |> # nolint: object_name_linter.
       dplyr::mutate(is_event = .data$CNSR == 0)
-    MAE <- hermes::multi_assay_experiment # nolint
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   })
   join_keys(data)["ADTTE", "ADTTE"] <- c("STUDYID", "USUBJID", "PARAMCD")
 

--- a/R/tm_g_pca.R
+++ b/R/tm_g_pca.R
@@ -481,7 +481,7 @@ srv_g_pca <- function(id,
 sample_tm_g_pca <- function(.test = FALSE) {
   data <- within(
     teal.data::teal_data(),
-    MAE <- hermes::multi_assay_experiment # nolint
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   )
   app <- teal::init(
     data = data,

--- a/R/tm_g_quality.R
+++ b/R/tm_g_quality.R
@@ -444,7 +444,7 @@ srv_g_quality <- function(id,
 sample_tm_g_quality <- function(.test = FALSE) {
   data <- within(
     teal.data::teal_data(),
-    MAE <- hermes::multi_assay_experiment # nolint
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   )
   app <- teal::init(
     data = data,

--- a/R/tm_g_scatterplot.R
+++ b/R/tm_g_scatterplot.R
@@ -265,7 +265,7 @@ srv_g_scatterplot <- function(id,
 sample_tm_g_scatterplot <- function(.test = FALSE) {
   data <- within(
     teal.data::teal_data(),
-    MAE <- hermes::multi_assay_experiment # nolint
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   )
   app <- teal::init(
     data = data,

--- a/R/tm_g_volcanoplot.R
+++ b/R/tm_g_volcanoplot.R
@@ -288,7 +288,7 @@ srv_g_volcanoplot <- function(id,
 sample_tm_g_volcanoplot <- function(.test = FALSE) {
   data <- within(
     teal.data::teal_data(),
-    MAE <- hermes::multi_assay_experiment # nolint
+    MAE <- hermes::multi_assay_experiment # nolint: object_name_linter.
   )
   app <- teal::init(
     data = data,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,4 +1,4 @@
-.onLoad <- function(libname, pkgname) { # nolint
+.onLoad <- function(libname, pkgname) {
   teal.logger::register_logger(namespace = "teal.modules.hermes")
   teal.logger::register_handlers("teal.modules.hermes")
 }

--- a/design/design_gene_names.R
+++ b/design/design_gene_names.R
@@ -20,7 +20,7 @@ ui <- function(id,
 }
 
 h_update_gene_selection2 <- function(session,
-                                     inputId, # nolint
+                                     inputId, # nolint: object_name_linter.
                                      selected,
                                      choice_data) {
   is_new_selected <- selected %in% choice_data$id

--- a/design/design_km2.R
+++ b/design/design_km2.R
@@ -8,7 +8,7 @@ gene_var2 <- c("GeneID:1820", "GeneID:94115")
 new_adtte <- h_km_mae_to_adtte(adtte, mae, gene_var = "GeneID:1820", experiment_name = "hd2")
 new_adtte2 <- h_km_mae_to_adtte(adtte, mae, gene_var = gene_var2, experiment_name = "hd2")
 
-ANL <- new_adtte # nolint
+ANL <- new_adtte # nolint: object_name_linter.
 names(ANL)
 arm_var <- attr(ANL, "gene_cols")
 mycode <- template_g_km_mae(arm_var = arm_var)

--- a/design/design_signature_module.Rmd
+++ b/design/design_signature_module.Rmd
@@ -16,11 +16,11 @@ library(checkmate)
 
 ## Objectives
 
-We need a shiny module that captures the gene signature logic. We might also need additional functions and classes which capture reused functionality. 
+We need a shiny module that captures the gene signature logic. We might also need additional functions and classes which capture reused functionality.
 
 ## Hermes Interface
 
-### Helpers 
+### Helpers
 
 ```{r}
 shorten_list <- function(x) {

--- a/man/multiSampleVarSpecServer.Rd
+++ b/man/multiSampleVarSpecServer.Rd
@@ -37,7 +37,7 @@ sample_var_specs <- multiSampleVarSpecServer(
   experiment_name = reactive({
     input$experiment_name
   }),
-  original_data = ori_data # nolint Please update the <ori_data>
+  original_data = ori_data # Please update the <ori_data>
 )
 # Then can extract the transformed data and selected variables later:
 experiment_data <- sample_var_specs$experiment_data()

--- a/tests/testthat/_snaps/forest.md
+++ b/tests/testthat/_snaps/forest.md
@@ -3,8 +3,8 @@
     Code
       cat(res)
     Output
-          group1 group1_level             avar_name                  row_name
-      1 row_type      content ac_n_tot_events_hr_ci n_tot_events.All Patients
+                 group1 group1_level             avar_name                  row_name
+      1 All patient row      content ac_n_tot_events_hr_ci n_tot_events.All Patients
           label_name row_num is_group_summary node_class V1 V2 V3           V4 V5 V6
       1 All Patients       1            FALSE    DataRow  5  5  3 222.1654....  4  2
                   V7           V8           V9

--- a/tests/testthat/adtteSpec/app.R
+++ b/tests/testthat/adtteSpec/app.R
@@ -55,7 +55,7 @@ server <- function(id,
       genes = genes,
       probs = reactive({
         0.5
-      }) # nolint
+      })
     )
     output$summary <- renderPrint({
       binned_adtte_subset <- adtte$binned_adtte_subset()

--- a/tests/testthat/helper-shinytest2.R
+++ b/tests/testthat/helper-shinytest2.R
@@ -2,11 +2,11 @@ library(shinytest2)
 
 module_ns_shiny2 <- function(app) {
   source <- app$get_html("html", outer_html = TRUE)
-  module_id <- rvest::html_attr(
-    rvest::html_node(rvest::read_html(source), css = ".teal_module"),
+  active_module_id <- rvest::html_attr(
+    rvest::html_node(rvest::read_html(source), css = ".teal_module.active"),
     "id"
   )
-  NS(paste0(module_id, "-module"))
+  NS(NS(gsub("-wrapper$", "", active_module_id), "module"))
 }
 
 default_app_seed <- 123

--- a/tests/testthat/helper-shinytest2.R
+++ b/tests/testthat/helper-shinytest2.R
@@ -1,12 +1,20 @@
 library(shinytest2)
 
-module_ns_shiny2 <- function(app) {
+active_module_parent_id <- function(app) {
   source <- app$get_html("html", outer_html = TRUE)
-  active_module_id <- rvest::html_attr(
+  active_module_wrapper_id <- rvest::html_attr(
     rvest::html_node(rvest::read_html(source), css = ".teal_module.active"),
     "id"
   )
-  NS(NS(gsub("-wrapper$", "", active_module_id), "module"))
+  gsub("-wrapper$", "", active_module_wrapper_id)
+}
+
+module_ns_shiny2 <- function(app) {
+  NS(NS(active_module_parent_id(app), "module"))
+}
+
+active_module_filter_panel_ns <- function(app) {
+  NS(NS(active_module_parent_id(app), "filter_panel-filters"))
 }
 
 default_app_seed <- 123

--- a/tests/testthat/setup-skip_if_too_deep.R
+++ b/tests/testthat/setup-skip_if_too_deep.R
@@ -7,7 +7,7 @@
 #'
 #' @return `numeric(1)` the testing depth.
 #'
-testing_depth <- function() { # nolint # nousage
+testing_depth <- function() { # nolint: object_name_linter. # nousage
   testing_depth <- getOption("TESTING_DEPTH")
   if (is.null(testing_depth)) testing_depth <- Sys.getenv("TESTING_DEPTH")
 
@@ -44,7 +44,7 @@ testing_depth <- function() { # nolint # nousage
 #' By default \code{depth} argument lower or equal to 3 will not be skipped because by default \code{TESTING_DEPTH}
 #' is equal to 3. To skip <= 3 depth tests then the environment variable has to be lower than 3 respectively.
 #' @export
-skip_if_too_deep <- function(depth) { # nolintr
+skip_if_too_deep <- function(depth) { # nolintr object_name_linter
   stopifnot(length(depth) == 1 && is.numeric(depth) && depth >= 0 && depth <= 5)
   test_to_depth <- testing_depth() # by default 3 if there are no env variable
   if (test_to_depth < depth) {

--- a/tests/testthat/test-adtteSpec.R
+++ b/tests/testthat/test-adtteSpec.R
@@ -193,6 +193,7 @@ test_that("adtteSpecServer module works as expected in the test app", {
 
   app$wait_for_idle(timeout = 20000)
   ns <- module_ns_shiny2(app)
+  ns_fp <- active_module_filter_panel_ns(app)
 
   # check initialization
   res <- app$get_values()
@@ -215,8 +216,13 @@ test_that("adtteSpecServer module works as expected in the test app", {
   res <- app$get_value(input = ns("adtte-paramcd"))
 
   # Test what happens if selected endpoint (here PFS) is no longer in filtered data.
-  app$set_inputs(`teal-teal_modules-adttespec_example-filter_panel-filters-ADTTE-ADTTE-filter-var_to_add` = "PARAMCD", allow_no_input_binding_ = TRUE)
-  app$set_inputs(`teal-teal_modules-adttespec_example-filter_panel-filters-ADTTE-filter-ADTTE_PARAMCD-inputs-selection` = "OS")
+  app$set_inputs(
+    !!ns_fp("ADTTE-ADTTE-filter-var_to_add") := "PARAMCD",
+    allow_no_input_binding_ = TRUE
+  )
+  app$set_inputs(
+    !!ns_fp("ADTTE-filter-ADTTE_PARAMCD-inputs-selection") := "OS"
+  )
   app$wait_for_idle(timeout = 20000)
   # We expect to get a validation message
   res <- app$get_value(input = ns("adtte-paramcd"))
@@ -226,12 +232,14 @@ test_that("adtteSpecServer module works as expected in the test app", {
 
   # Now we update the filter by adding PFS back. However the user would have to
   # actively select it.
-  app$set_inputs(`teal-teal_modules-adttespec_example-filter_panel-filters-ADTTE-filter-ADTTE_PARAMCD-inputs-selection` := c("PFS", "OS"))
+  app$set_inputs(
+    !!ns_fp("ADTTE-filter-ADTTE_PARAMCD-inputs-selection") := c("PFS", "OS")
+  )
   app$wait_for_idle()
   res <- app$get_value(output = ns("summary"))
   expect_equal(res$message, "please select an endpoint")
 
-  app$click("teal-teal_modules-adttespec_example-filter_panel-filters-ADTTE-filter-ADTTE_PARAMCD-remove")
+  app$click(ns_fp("ADTTE-filter-ADTTE_PARAMCD-remove"))
   app$stop()
 })
 

--- a/tests/testthat/test-adtteSpec.R
+++ b/tests/testthat/test-adtteSpec.R
@@ -17,7 +17,7 @@ test_that("h_km_mae_to_adtte function works as expected with a single gene", {
 
 test_that("h_km_mae_to_adtte function also works when some ID variables are factors", {
   mae <- hermes::multi_assay_experiment
-  SummarizedExperiment::colData(mae)$USUBJID <- # nolint
+  SummarizedExperiment::colData(mae)$USUBJID <- # nolint: object_name_linter.
     factor(SummarizedExperiment::colData(mae)$USUBJID)
   adtte <- teal.data::rADTTE %>%
     dplyr::mutate(USUBJID = factor(USUBJID))
@@ -178,8 +178,6 @@ test_that("adtteSpecInput creates expected HTML", {
   expect_class(result, "shiny.tag")
 })
 
-# nolint start
-
 test_that("adtteSpecServer module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -242,5 +240,3 @@ test_that("adtteSpecServer module works as expected in the test app", {
   app$click(ns_fp("ADTTE-filter-ADTTE_PARAMCD-remove"))
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-assaySpec.R
+++ b/tests/testthat/test-assaySpec.R
@@ -9,8 +9,6 @@ test_that("assaySpecInput creates expected HTML", {
   expect_class(result, "shiny.tag")
 })
 
-# nolint start
-
 # assaySpecServer ----
 test_that("assaySpecServer module works as expected in the test app", {
   skip_if_covr()
@@ -54,5 +52,3 @@ test_that("assaySpecServer module works as expected in the test app", {
 
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-barplot.R
+++ b/tests/testthat/test-barplot.R
@@ -19,8 +19,6 @@ test_that("ui_g_barplot creates expected HTML", {
 
 # tm_g_barplot ----
 
-# nolint start
-
 test_that("barplot module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -97,5 +95,3 @@ test_that("barplot module works as expected in the test app", {
 
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-boxplot.R
+++ b/tests/testthat/test-boxplot.R
@@ -15,8 +15,6 @@ test_that("ui_g_boxplot creates expected HTML", {
 
 # tm_g_boxplot ----
 
-# nolint start
-
 test_that("boxplot module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -64,5 +62,3 @@ test_that("boxplot module works as expected in the test app", {
 
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-experimentSpec.R
+++ b/tests/testthat/test-experimentSpec.R
@@ -89,8 +89,6 @@ test_that("h_gene_data does not fail when object does not contain any genes", {
   expect_identical(result, expected)
 })
 
-# nolint start
-
 test_that("experimentSpec module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -170,5 +168,3 @@ test_that("experimentSpec module works as expected in the test app", {
 
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-experimentSpec.R
+++ b/tests/testthat/test-experimentSpec.R
@@ -150,15 +150,16 @@ test_that("experimentSpec module works as expected in the test app", {
   expect_match(res, "HermesData object with 9 samples of 2500 genes")
 
   # Filtering out all samples using right side panel
-  app$set_inputs(`teal-teal_modules-experimentspec_example-filter_panel-filters-MAE-MAE-subjects-var_to_add` = "AGE18", allow_no_input_binding_ = TRUE)
-  app$set_inputs(`teal-teal_modules-experimentspec_example-filter_panel-filters-MAE-subjects-MAE_AGE18-inputs-selection` = character(0))
+  ns_fp <- active_module_filter_panel_ns(app)
+  app$set_inputs(!!ns_fp("MAE-MAE-subjects-var_to_add") := "AGE18", allow_no_input_binding_ = TRUE)
+  app$set_inputs(!!ns_fp("MAE-subjects-MAE_AGE18-inputs-selection") := character(0))
   app$wait_for_idle()
   # Experiment selection is not affected by filtering
   res <- app$get_value(input = ns("my_experiment-name"))
   expect_identical(res, "hd2")
   res <- app$get_value(output = ns("summary"))
   expect_match(res$message, "No genes or samples included in this experiment, please adjust filters")
-  app$click("teal-teal_modules-experimentspec_example-filter_panel-filters-MAE-subjects-MAE_AGE18-remove")
+  app$click(ns_fp("MAE-subjects-MAE_AGE18-remove"))
 
   # Experiment selection is not affected by removing filters
   res <- app$get_value(input = ns("my_experiment-name"))

--- a/tests/testthat/test-forest.R
+++ b/tests/testthat/test-forest.R
@@ -19,8 +19,6 @@ test_that("ui_g_forest_tte creates expected HTML", {
 
 # tm_g_forest_tte ----
 
-# nolint start
-
 test_that("forest_tte module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -68,5 +66,3 @@ test_that("forest_tte module works as expected in the test app", {
 
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-geneSpec.R
+++ b/tests/testthat/test-geneSpec.R
@@ -77,9 +77,10 @@ test_that("geneSpec module works as expected in the test app", {
   app$set_inputs(!!ns("my_genes-lock_button") := TRUE)
 
   # Filter data using the right side panel
-  app$set_inputs(`teal-teal_modules-genespec_example-filter_panel-filters-MAE-MAE-hd1-row_to_add` = "chromosome", allow_no_input_binding_ = TRUE)
-  app$set_inputs(`teal-teal_modules-genespec_example-filter_panel-filters-MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection` = c("1", "2"))
-  app$set_inputs(`teal-teal_modules-genespec_example-filter_panel-filters-MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open` = FALSE, allow_no_input_binding_ = TRUE)
+  ns_fp <- active_module_filter_panel_ns(app)
+  app$set_inputs(!!ns_fp("MAE-MAE-hd1-row_to_add") := "chromosome", allow_no_input_binding_ = TRUE)
+  app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection") := c("1", "2"))
+  app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open") := FALSE, allow_no_input_binding_ = TRUE)
   app$wait_for_idle()
 
   # Confirm that gene selection was not changed.
@@ -108,7 +109,7 @@ test_that("geneSpec module works as expected in the test app", {
   expect_identical(res, "mean(ACP1, ACTN2)")
 
   # Remove the filter.
-  app$click("teal-teal_modules-genespec_example-filter_panel-filters-MAE-hd1-MAE_chromosome_hd1_subset-remove")
+  app$click(ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-remove"))
 
   # Select a gene via text input.
   app$click(ns("my_genes-text_button"))

--- a/tests/testthat/test-geneSpec.R
+++ b/tests/testthat/test-geneSpec.R
@@ -32,8 +32,6 @@ test_that("h_parse_genes correctly returns empty data frame when no genes match"
 
 # geneSpecServer ----
 
-# nolint start
-
 test_that("geneSpec module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -80,7 +78,10 @@ test_that("geneSpec module works as expected in the test app", {
   ns_fp <- active_module_filter_panel_ns(app)
   app$set_inputs(!!ns_fp("MAE-MAE-hd1-row_to_add") := "chromosome", allow_no_input_binding_ = TRUE)
   app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection") := c("1", "2"))
-  app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open") := FALSE, allow_no_input_binding_ = TRUE)
+  app$set_inputs(
+    !!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open") := FALSE,
+    allow_no_input_binding_ = TRUE
+  )
   app$wait_for_idle()
 
   # Confirm that gene selection was not changed.
@@ -122,5 +123,3 @@ test_that("geneSpec module works as expected in the test app", {
 
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-km.R
+++ b/tests/testthat/test-km.R
@@ -20,8 +20,6 @@ test_that("ui_g_km creates expected HTML", {
 
 # tm_g_km ----
 
-# nolint start
-
 test_that("km module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -66,5 +64,3 @@ test_that("km module works as expected in the test app", {
   )
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -14,8 +14,6 @@ test_that("ui_g_pca creates HTML", {
 
 # pca Server ----
 
-# nolint start
-
 test_that("pca module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -65,7 +63,10 @@ test_that("pca module works as expected in the test app", {
   ns_fp <- active_module_filter_panel_ns(app)
   app$set_inputs(!!ns_fp("MAE-MAE-hd1-row_to_add") := "chromosome", allow_no_input_binding_ = TRUE)
   app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection") := character())
-  app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open") := FALSE, allow_no_input_binding_ = TRUE)
+  app$set_inputs(
+    !!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open") := FALSE,
+    allow_no_input_binding_ = TRUE
+  )
   app$wait_for_idle()
 
   res <- app$get_value(output = ns("test_pca"))
@@ -231,5 +232,3 @@ test_that("pca module works as expected in the test app", {
   expect_identical(res, 2500L)
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-pca.R
+++ b/tests/testthat/test-pca.R
@@ -62,16 +62,17 @@ test_that("pca module works as expected in the test app", {
   )
 
   # Add a gene filter and deselect everything and check that it does not crash.
-  app$set_inputs(`teal-teal_modules-pca-filter_panel-filters-MAE-MAE-hd1-row_to_add` = "chromosome", allow_no_input_binding_ = TRUE)
-  app$set_inputs(`teal-teal_modules-pca-filter_panel-filters-MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection` = character())
-  app$set_inputs(`teal-teal_modules-pca-filter_panel-filters-MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open` = FALSE, allow_no_input_binding_ = TRUE)
+  ns_fp <- active_module_filter_panel_ns(app)
+  app$set_inputs(!!ns_fp("MAE-MAE-hd1-row_to_add") := "chromosome", allow_no_input_binding_ = TRUE)
+  app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection") := character())
+  app$set_inputs(!!ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-inputs-selection_open") := FALSE, allow_no_input_binding_ = TRUE)
   app$wait_for_idle()
 
   res <- app$get_value(output = ns("test_pca"))
   expect_match(res$message, "No genes or samples included in this experiment, please adjust filters")
 
   # Remove filters
-  app$click("teal-teal_modules-pca-filter_panel-filters-MAE-hd1-MAE_chromosome_hd1_subset-remove")
+  app$click(ns_fp("MAE-hd1-MAE_chromosome_hd1_subset-remove"))
   app$wait_for_idle()
 
   # Update the tab selection.
@@ -170,9 +171,9 @@ test_that("pca module works as expected in the test app", {
   app$set_inputs(!!ns("show_matrix") := TRUE)
 
   app$wait_for_idle(timeout = 40000)
-  app$set_inputs(`teal-teal_modules-pca-filter_panel-filters-MAE-MAE-subjects-var_to_add` = "SEX", allow_no_input_binding_ = TRUE)
-  app$set_inputs(`teal-teal_modules-pca-filter_panel-filters-MAE-subjects-MAE_SEX-inputs-selection` = "F")
-  app$set_inputs(`teal-teal_modules-pca-filter_panel-filters-MAE-subjects-MAE_SEX-inputs-selection_open` = FALSE, allow_no_input_binding_ = TRUE)
+  app$set_inputs(!!ns_fp("MAE-MAE-subjects-var_to_add") := "SEX", allow_no_input_binding_ = TRUE)
+  app$set_inputs(!!ns_fp("MAE-subjects-MAE_SEX-inputs-selection") := "F")
+  app$set_inputs(!!ns_fp("MAE-subjects-MAE_SEX-inputs-selection_open") := FALSE, allow_no_input_binding_ = TRUE)
 
   # Ensure xvar and yvar DONT get reset.
   app$wait_for_idle(timeout = 20000)
@@ -186,7 +187,7 @@ test_that("pca module works as expected in the test app", {
   expect_identical(res$message, "Sample size is too small. PCA needs more than 2 samples.")
 
   # Remove filter.
-  app$click("teal-teal_modules-pca-filter_panel-filters-MAE-subjects-MAE_SEX-remove")
+  app$click(ns_fp("MAE-subjects-MAE_SEX-remove"))
 
   # Initiate the use of Top Variance Genes filtering functionality.
   app$set_inputs(!!ns("filter_top") := TRUE)

--- a/tests/testthat/test-quality.R
+++ b/tests/testthat/test-quality.R
@@ -16,8 +16,6 @@ test_that("ui_g_quality creates expected HTML", {
 
 # tm_g_quality ----
 
-# nolint start
-
 test_that("quality module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -81,5 +79,3 @@ test_that("quality module works as expected in the test app", {
   )
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-sampleVarSpec.R
+++ b/tests/testthat/test-sampleVarSpec.R
@@ -166,8 +166,6 @@ test_that("sampleVarSpecServer only gives factor columns in col_data_vars when c
   )
 })
 
-# nolint start
-
 test_that("sampleVarSpec module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -224,5 +222,3 @@ test_that("sampleVarSpec module works as expected in the test app", {
   expect_match(res, "< 18/>= 18 \n         5 ")
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-sampleVarSpec.R
+++ b/tests/testthat/test-sampleVarSpec.R
@@ -195,17 +195,19 @@ test_that("sampleVarSpec module works as expected in the test app", {
   expect_match(as.character(res), " < 18 >= 18 \n    4     1 ")
 
   # Filter panel works as expected
-  app$click(selector = "#teal-teal_modules-samplevarspec_example-filter_panel-filters-MAE-filter_util_icons a i")
+  ns_fp <- active_module_filter_panel_ns(app)
+
+  # app$click(selector = "#teal-teal_modules-samplevarspec_example-filter_panel-filters-MAE-filter_util_icons a i")
   app$wait_for_idle()
-  app$set_inputs("teal-teal_modules-samplevarspec_example-filter_panel-filters-MAE-MAE-subjects-var_to_add" = "AGE18")
+  app$set_inputs(!!ns_fp("MAE-MAE-subjects-var_to_add") := "AGE18")
   app$wait_for_idle()
-  app$set_inputs("teal-teal_modules-samplevarspec_example-filter_panel-filters-MAE-subjects-MAE_AGE18-inputs-selection" = "< 18")
+  app$set_inputs(!!ns_fp("MAE-subjects-MAE_AGE18-inputs-selection") := "< 18")
   app$wait_for_idle()
 
   res <- app$get_value(output = ns("summary"))
   expect_equal(res, "< 18 \n   4 ")
 
-  app$click("teal-teal_modules-samplevarspec_example-filter_panel-filters-MAE-subjects-MAE_AGE18-remove")
+  app$click(ns_fp("MAE-subjects-MAE_AGE18-remove"))
   app$wait_for_idle()
   res <- app$get_value(output = ns("summary"))
   expect_equal(res, " < 18 >= 18 \n    4     1 ")

--- a/tests/testthat/test-sampleVarSpec.R
+++ b/tests/testthat/test-sampleVarSpec.R
@@ -196,10 +196,7 @@ test_that("sampleVarSpec module works as expected in the test app", {
 
   # Filter panel works as expected
   ns_fp <- active_module_filter_panel_ns(app)
-
-  # app$click(selector = "#teal-teal_modules-samplevarspec_example-filter_panel-filters-MAE-filter_util_icons a i")
-  app$wait_for_idle()
-  app$set_inputs(!!ns_fp("MAE-MAE-subjects-var_to_add") := "AGE18")
+  app$set_inputs(!!ns_fp("MAE-MAE-subjects-var_to_add") := "AGE18", allow_no_input_binding_ = TRUE)
   app$wait_for_idle()
   app$set_inputs(!!ns_fp("MAE-subjects-MAE_AGE18-inputs-selection") := "< 18")
   app$wait_for_idle()

--- a/tests/testthat/test-scatterplot.R
+++ b/tests/testthat/test-scatterplot.R
@@ -19,8 +19,6 @@ test_that("ui_g_scatterplot creates expected HTML", {
 
 # tm_g_scatterplot ----
 
-# nolint start
-
 test_that("scatterplot module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -102,5 +100,3 @@ test_that("scatterplot module works as expected in the test app", {
 
   app$stop()
 })
-
-# nolint end

--- a/tests/testthat/test-scatterplot.R
+++ b/tests/testthat/test-scatterplot.R
@@ -67,8 +67,9 @@ test_that("scatterplot module works as expected in the test app", {
   # Change the sample filter and confirm that genes are not updated.
 
   # Filtering out all samples using right side panel
-  app$set_inputs(`teal-teal_modules-scatterplot-filter_panel-filters-MAE-MAE-subjects-var_to_add` = "SEX", allow_no_input_binding_ = TRUE)
-  app$set_inputs(`teal-teal_modules-scatterplot-filter_panel-filters-MAE-subjects-MAE_SEX-inputs-selection` = "F")
+  ns_fp <- active_module_filter_panel_ns(app)
+  app$set_inputs(!!ns_fp("MAE-MAE-subjects-var_to_add") := "SEX", allow_no_input_binding_ = TRUE)
+  app$set_inputs(!!ns_fp("MAE-subjects-MAE_SEX-inputs-selection") := "F")
   app$wait_for_idle()
 
   app$wait_for_idle()
@@ -78,7 +79,7 @@ test_that("scatterplot module works as expected in the test app", {
   expect_identical(res, "GeneID:8086")
 
   # Remove sample filter
-  app$click("teal-teal_modules-scatterplot-filter_panel-filters-MAE-subjects-MAE_SEX-remove")
+  app$click(ns_fp("MAE-subjects-MAE_SEX-remove"))
   app$wait_for_idle()
 
   res <- app$get_value(input = ns("x_spec-genes"))

--- a/tests/testthat/test-volcanoplot.R
+++ b/tests/testthat/test-volcanoplot.R
@@ -14,8 +14,6 @@ test_that("ui_g_volcanoplot creates expected HTML", {
 
 # tm_g_volcanoplot ----
 
-# nolint start
-
 test_that("volcanoplot module works as expected in the test app", {
   skip_if_covr()
   skip_if_too_deep(5)
@@ -57,5 +55,3 @@ test_that("volcanoplot module works as expected in the test app", {
   expect_snapshot(cat(res))
   app$stop()
 })
-
-# nolint end


### PR DESCRIPTION
Install teal.slice as important fix has been merged recently (https://github.com/insightsengineering/teal.slice/pull/663). Please remember to install teal.slice locally if you want to test this branch - shinytest2 is run in the separate session so every packages must be installed (load_all has no effect).

In this PR:
- needed to replace hardcoded ids of filter panel inputs with a functional approach `!!ns_fs(<input path>) := <input value> `. Thanks to this we just need to change "id" in one place if we ever change the namespace in teal or teal.slice

