### PR TITLE
chore: bump teal.reporter dependency to 0.5.0 and remove from Remotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -51,7 +51,7 @@ Imports:
     SummarizedExperiment (>= 1.36.0),
     teal.data (>= 0.7.0),
     teal.logger (>= 0.4.0),
-    teal.reporter (>= 0.4.0.9005),
+    teal.reporter (>= 0.5.0),
     teal.widgets (>= 0.4.3.9001),
     tern (>= 0.9.7),
     utils
@@ -71,7 +71,6 @@ Suggests:
 VignetteBuilder:
     knitr
 Remotes:
-    insightsengineering/teal.reporter@main,
     insightsengineering/teal.widgets@main,
     insightsengineering/teal@main
 biocViews:


### PR DESCRIPTION
This PR updates all DESCRIPTION files to require teal.reporter (>= 0.5.0) and removes it from Remotes.